### PR TITLE
Update Kibana config with v7 hosts setting

### DIFF
--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -4,4 +4,4 @@
 #
 server.name: kibana
 server.host: "0"
-elasticsearch.url: http://elasticsearch:9200
+elasticsearch.hosts: http://elasticsearch:9200


### PR DESCRIPTION
v7 of Kibana expects `elasticsearch.hosts` rather than `elasticsearch.url`, see:
https://www.elastic.co/guide/en/kibana/7.0/settings.html

Fixes the problem where Kibana docker container fails to start with error:
FATAL  ValidationError: child "elasticsearch" fails because ["url" is not allowed]