### PR TITLE
Single set instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Local service sets definitions and environment
 /service-sets/*.local.yaml
 /.env/
+/.active-set
 
 # Various temp files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -63,16 +63,20 @@ services:
   - redis-5.0
 ```
 
-**NOTE:** You can define multiple custom service sets, however it is recomended to use them one at a time. All services use same bridge network, so if a service is included in multiple sets, Docker Compose will allocate distinct names for the service in different sets, but they will still use same network port, so only one service can be active at a time that uses that port.
+**NOTE:** You can define multiple custom service sets, however it is only possible to use them one at a time. All services use same bridge network, so if a service is included in multiple sets, Docker Compose will allocate distinct names for the service in different sets, but they will still use same network port, so only one service can be active at a time that uses that port.
 
 ### Start
 
+Start service set by name:
+
 ```bash
-start.ps1 -Set <set-name>
+start.ps1 <set-name>
 ```
 
 ### Stop
 
+Stop service set that was previously started by `start.ps1 <set-name>`.
+
 ```bash
-stop.ps1 -Set <set-name>
+stop.ps1
 ```

--- a/services/elasticsearch-7.5/service.env
+++ b/services/elasticsearch-7.5/service.env
@@ -1,1 +1,1 @@
-ES_JAVA_OPTS="-Xmx512m -Xms512m"
+

--- a/services/logstash-7.5/service.env
+++ b/services/logstash-7.5/service.env
@@ -1,1 +1,0 @@
-ES_JAVA_OPTS="-Xmx512m -Xms512m"

--- a/stop.ps1
+++ b/stop.ps1
@@ -1,10 +1,7 @@
 #!/usr/bin/env pwsh
 
 Param(
-    [ValidateNotNullOrEmpty()]
-    [string]$Set = 'default',
-
     [switch]$Verbose
 )
 
-. $PSScriptRoot/docker-dev-services.ps1 -Set $Set -Action Stop -Verbose:$Verbose
+. $PSScriptRoot/docker-dev-services.ps1 -Action Stop -Verbose:$Verbose


### PR DESCRIPTION
- Only allow one active set at a time.
- `stop.ps1` does not require set name anymore - it will stop the set that currently active.